### PR TITLE
ci: Add auto PR creation for Claude GitHub Actions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -47,4 +47,34 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
+
+      - name: Create PR if Claude pushed a branch
+        if: github.event_name == 'issue_comment' || github.event_name == 'issues'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch all remote branches
+          git fetch --all
+
+          # Get the issue number
+          ISSUE_NUMBER="${{ github.event.issue.number }}"
+
+          # Find branches created by Claude for this issue
+          BRANCH=$(git branch -r --list "origin/claude/issue-${ISSUE_NUMBER}-*" | head -1 | sed 's/origin\///' | xargs)
+
+          if [ -n "$BRANCH" ]; then
+            # Check if PR already exists for this branch
+            EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+
+            if [ -z "$EXISTING_PR" ]; then
+              echo "Creating PR for branch: $BRANCH"
+              ISSUE_TITLE=$(gh issue view $ISSUE_NUMBER --json title --jq '.title')
+              PR_BODY="Closes #${ISSUE_NUMBER}"$'\n\n'"This PR was automatically created by Claude Code."$'\n\n'"🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+              gh pr create --head "$BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY"
+            else
+              echo "PR already exists: #$EXISTING_PR"
+            fi
+          else
+            echo "No Claude branch found for issue #$ISSUE_NUMBER"
+          fi
 


### PR DESCRIPTION
## Summary
- Updates Claude workflow to automatically create PRs when Claude finishes working on an issue
- Changes permissions from read to write for contents, pull-requests, and issues
- After Claude pushes a branch, the workflow will:
  - Detect branches named `claude/issue-{NUMBER}-*`
  - Check if a PR already exists
  - Create a PR automatically if none exists

## Why
Claude GitHub Actions cannot create PRs through the API directly - it can only provide links. This workaround uses the `gh` CLI in a subsequent step to create the PR automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)