### PR TITLE
Add PR template and enforce issue reference requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+## Description
+<!-- Provide a clear and concise description of your changes -->
+
+## Related Issue
+<!-- This PR must reference an issue. Use one of the following formats: -->
+<!-- Closes #123, Fixes #123, or Resolves #123 -->
+
+**Closes #**
+
+## Type of Change
+<!-- Check the relevant option(s) -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring
+- [ ] Performance improvement
+- [ ] Other (please describe):
+
+## Testing
+<!-- Describe the testing you've performed -->
+
+- [ ] Tested in Chrome/Edge
+- [ ] Tested in Firefox
+- [ ] Tested in Safari (if available)
+- [ ] Tested on mobile viewport
+- [ ] Tested keyboard navigation
+- [ ] All existing features still work
+
+## Checklist
+<!-- Check all that apply -->
+
+- [ ] My code follows the project's coding standards (see AI_CONTEXT.md)
+- [ ] I have updated CHANGELOG.md with my changes
+- [ ] I have updated README.md (if applicable)
+- [ ] I have tested my changes by opening index.html in a browser
+- [ ] This PR references an issue number above
+- [ ] My changes maintain the zero-dependency philosophy (vanilla HTML/CSS/JS only)
+
+## Screenshots (if applicable)
+<!-- Add screenshots to help explain your changes -->
+
+## Additional Notes
+<!-- Add any other context about the pull request here -->

--- a/.github/WORKFLOW_ENHANCEMENTS.md
+++ b/.github/WORKFLOW_ENHANCEMENTS.md
@@ -1,0 +1,176 @@
+# GitHub Workflow Enhancement Guide
+
+This document provides instructions for enhancing the GitHub Actions workflow to enforce PR requirements and enable additional Claude capabilities.
+
+## Overview
+
+This repository now has a PR template that requires all pull requests to reference an issue. To enforce this requirement automatically, you can add a validation step to your GitHub Actions workflow.
+
+## 1. PR Validation Workflow (Enforce Issue References)
+
+### Option A: Add to Existing Workflow
+
+Add this step to `.github/workflows/claude.yml` or create a separate workflow file:
+
+```yaml
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR references an issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const issuePattern = /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+/i;
+
+            if (!issuePattern.test(prBody)) {
+              core.setFailed('PR must reference an issue using "Closes #X", "Fixes #X", or "Resolves #X"');
+            } else {
+              core.info('✓ PR correctly references an issue');
+            }
+```
+
+### Option B: Use Branch Protection Rules
+
+Instead of a workflow, you can use GitHub's built-in branch protection:
+
+1. Go to repository Settings → Branches
+2. Add a branch protection rule for `main`
+3. Enable "Require pull request reviews before merging"
+4. Enable "Require status checks to pass before merging"
+5. GitHub will automatically detect issue links in PRs
+
+## 2. Claude Issue Creation Capability
+
+The current workflow already has the necessary permissions for Claude to create issues:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write  # This permission allows issue creation
+  id-token: write
+  actions: read
+```
+
+### How Claude Creates Issues
+
+Claude can create issues through the GitHub CLI (`gh`) when invoked with appropriate commands:
+
+```bash
+gh issue create --title "Issue Title" --body "Issue description"
+```
+
+### Example Workflow Integration
+
+If you want to allow Claude to create issues via a specific trigger, you can add a custom comment command:
+
+```yaml
+# In .github/workflows/claude.yml
+# Claude already has access to gh CLI and can create issues when needed
+# No additional configuration required
+```
+
+## 3. Automated PR-Issue Linking
+
+Your current workflow already automatically creates PRs with issue references:
+
+```yaml
+PR_BODY="Closes #${ISSUE_NUMBER}"$'\n\n'"This PR was automatically created by Claude Code."
+```
+
+This is working correctly and needs no changes.
+
+## 4. Recommended Implementation Steps
+
+1. **Add PR Validation** (Choose one):
+   - Add the PR validation workflow above as `.github/workflows/pr-validation.yml`
+   - OR enable branch protection rules in repository settings
+
+2. **Test the Setup**:
+   - Create a test PR without an issue reference → should fail validation
+   - Create a test PR with "Closes #X" → should pass validation
+
+3. **Update Team Documentation**:
+   - Inform contributors about the new requirements
+   - The PR template will guide them automatically
+
+## 5. Additional Enhancements (Optional)
+
+### Auto-Label PRs by Type
+
+```yaml
+name: Auto Label PR
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const prBody = context.payload.pull_request.body || '';
+            const labels = [];
+
+            if (prBody.includes('[x] Bug fix')) labels.push('bug');
+            if (prBody.includes('[x] New feature')) labels.push('enhancement');
+            if (prBody.includes('[x] Documentation')) labels.push('documentation');
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labels
+              });
+            }
+```
+
+### PR Size Labeling
+
+```yaml
+name: PR Size Labeling
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_label: 'size/xs'
+          xs_max_size: '10'
+          s_label: 'size/s'
+          s_max_size: '100'
+          m_label: 'size/m'
+          m_max_size: '500'
+          l_label: 'size/l'
+          l_max_size: '1000'
+          xl_label: 'size/xl'
+```
+
+## Questions?
+
+If you need help implementing these enhancements, please refer to:
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [GitHub Branch Protection Rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)
+- Create an issue in this repository for specific questions
+
+---
+
+**Note**: These enhancements are optional but recommended for maintaining code quality and traceability between issues and pull requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **GitHub Workflow**: Created PR template (`.github/PULL_REQUEST_TEMPLATE.md`) requiring issue references
+- **Documentation**: Enhanced `CONTRIBUTING.md` with PR requirements and workflow guidelines
+- **Documentation**: Added `.github/WORKFLOW_ENHANCEMENTS.md` with instructions for optional workflow validations
+
+### Changed
+- **Contributing**: Pull requests now must reference an issue using `Closes #X`, `Fixes #X`, or `Resolves #X`
+
 ## [1.5.0] - 2025-12-10
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,21 @@ If you are using an AI agent to work on this repository:
 
 ## Pull Requests
 
-1.  Ensure your changes work by manually testing in a browser.
-2.  Update the `CHANGELOG.md` with a description of your changes.
-3.  Submit your PR!
+All pull requests must reference an issue. If an issue doesn't exist for your proposed change, please create one first.
+
+### PR Requirements
+
+1.  **Link to an Issue**: Your PR must reference an issue using `Closes #X`, `Fixes #X`, or `Resolves #X` in the description.
+2.  **Manual Testing**: Ensure your changes work by testing in a browser (Chrome, Firefox, Safari if available).
+3.  **Update Documentation**: Update `CHANGELOG.md` with a description of your changes under the `[Unreleased]` section.
+4.  **Update README**: If your changes affect features or usage, update `README.md` accordingly.
+5.  **Follow the PR Template**: Complete all relevant sections of the PR template when creating your pull request.
+
+### Creating a Pull Request
+
+1.  Create or identify an existing issue that describes what you want to change
+2.  Fork the repository and create a new branch from `main`
+3.  Make your changes following the development guidelines above
+4.  Test thoroughly in multiple browsers
+5.  Update `CHANGELOG.md` and `README.md` if needed
+6.  Submit your PR using the PR template and ensure it references the issue


### PR DESCRIPTION
Closes #26

This PR implements GitHub workflow improvements to enforce that all pull requests reference an issue and provides documentation for enhanced workflow capabilities.

## Changes
- Created PR template requiring issue references
- Updated CONTRIBUTING.md with PR requirements
- Added workflow enhancement documentation
- Updated CHANGELOG.md

Generated with [Claude Code](https://claude.ai/code)