### PR TITLE
Add translated file input for logo uploader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added (SvelteKit Migration)
+- **i18n**: Added translated file input for logo uploader
+  - Custom styled file input button with translations
+  - English: "Choose file" / "No file chosen"
+  - Spanish: "Seleccionar archivo" / "Ningún archivo"
+
 ### Added
 - **Internationalization**: Added Spanish (Latin America) language support
   - Created translations.js with English and Spanish translations

--- a/sveltekit/src/lib/components/LogoUploader.svelte
+++ b/sveltekit/src/lib/components/LogoUploader.svelte
@@ -3,12 +3,14 @@
 	import { t } from '$lib/stores/language';
 
 	let fileInput: HTMLInputElement;
+	let fileName = $state('');
 
 	function handleFileChange(event: Event) {
 		const target = event.target as HTMLInputElement;
 		const file = target.files?.[0];
 
 		if (file) {
+			fileName = file.name;
 			const reader = new FileReader();
 			reader.onload = (e) => {
 				const result = e.target?.result;
@@ -22,9 +24,14 @@
 
 	function clearLogo() {
 		qrSettings.clearLogo();
+		fileName = '';
 		if (fileInput) {
 			fileInput.value = '';
 		}
+	}
+
+	function triggerFileInput() {
+		fileInput?.click();
 	}
 </script>
 
@@ -37,7 +44,12 @@
 			accept="image/png, image/jpeg, image/svg+xml"
 			bind:this={fileInput}
 			onchange={handleFileChange}
+			class="hidden-input"
 		/>
+		<button type="button" class="btn btn-file" onclick={triggerFileInput}>
+			{$t.chooseFile}
+		</button>
+		<span class="file-name">{fileName || $t.noFileChosen}</span>
 		{#if $qrSettings.logoDataUrl}
 			<button class="btn btn-secondary btn-sm" onclick={clearLogo}>
 				{$t.clearLogoBtn}
@@ -65,8 +77,16 @@
 		flex-wrap: wrap;
 	}
 
-	input[type='file'] {
-		font-size: 0.9rem;
+	.hidden-input {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.btn {
@@ -76,6 +96,39 @@
 		cursor: pointer;
 		font-size: 0.85rem;
 		transition: background-color 0.2s;
+	}
+
+	.btn-file {
+		background: #e2e8f0;
+		color: #4a5568;
+		border: 1px solid #cbd5e0;
+	}
+
+	.btn-file:hover {
+		background: #cbd5e0;
+	}
+
+	:global(.dark-mode) .btn-file {
+		background: #4a5568;
+		color: #e2e8f0;
+		border-color: #718096;
+	}
+
+	:global(.dark-mode) .btn-file:hover {
+		background: #718096;
+	}
+
+	.file-name {
+		font-size: 0.85rem;
+		color: #718096;
+		max-width: 150px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	:global(.dark-mode) .file-name {
+		color: #a0aec0;
 	}
 
 	.btn-secondary {

--- a/sveltekit/src/lib/stores/language.ts
+++ b/sveltekit/src/lib/stores/language.ts
@@ -14,6 +14,8 @@ export type TranslationKey =
 	| 'colorLabel'
 	| 'logoLabel'
 	| 'clearLogoBtn'
+	| 'chooseFile'
+	| 'noFileChosen'
 	| 'sizeSmall'
 	| 'sizeMedium'
 	| 'sizeLarge'
@@ -47,6 +49,8 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		colorLabel: 'Color',
 		logoLabel: 'Logo (Optional)',
 		clearLogoBtn: 'Clear',
+		chooseFile: 'Choose file',
+		noFileChosen: 'No file chosen',
 		sizeSmall: 'Small (128px)',
 		sizeMedium: 'Medium (200px)',
 		sizeLarge: 'Large (300px)',
@@ -79,6 +83,8 @@ export const translations: Record<Language, Record<TranslationKey, string>> = {
 		colorLabel: 'Color',
 		logoLabel: 'Logo (Opcional)',
 		clearLogoBtn: 'Limpiar',
+		chooseFile: 'Seleccionar archivo',
+		noFileChosen: 'Ningún archivo',
 		sizeSmall: 'Pequeño (128px)',
 		sizeMedium: 'Mediano (200px)',
 		sizeLarge: 'Grande (300px)',


### PR DESCRIPTION
## Summary
- Add `chooseFile` and `noFileChosen` translation keys to the i18n system
- Replace native browser file input with custom styled button that shows translated text
- File input now displays translated "Choose file" / "No file chosen" text

## Changes
**`src/lib/stores/language.ts`:**
- Added `chooseFile`: "Choose file" / "Seleccionar archivo"
- Added `noFileChosen`: "No file chosen" / "Ningún archivo"

**`src/lib/components/LogoUploader.svelte`:**
- Hidden native file input (visually hidden but accessible)
- Custom button triggers file selection
- Displays file name after selection or translated placeholder
- Dark mode styling included

## Test plan
- [ ] Switch to Spanish mode - verify "Seleccionar archivo" and "Ningún archivo" appear
- [ ] Switch to English mode - verify "Choose file" and "No file chosen" appear
- [ ] Upload a file - verify file name displays correctly
- [ ] Clear logo - verify placeholder text returns

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)